### PR TITLE
use <pre> instead of <code>

### DIFF
--- a/app/code_highlight/config/dependencies.rb
+++ b/app/code_highlight/config/dependencies.rb
@@ -1,4 +1,4 @@
 # Component dependencies
 disable_auto_import
 
-javascript_file '/assets/code_highlight/assets/js/highlight.pack.js'
+javascript_file '/app/code_highlight/assets/js/highlight.pack.js'

--- a/app/code_highlight/config/dependencies.rb
+++ b/app/code_highlight/config/dependencies.rb
@@ -1,5 +1,4 @@
 # Component dependencies
 disable_auto_import
 
-css_file '/assets/code_highlight/assets/css/sunburst.css'
 javascript_file '/assets/code_highlight/assets/js/highlight.pack.js'

--- a/app/code_highlight/config/dependencies.rb
+++ b/app/code_highlight/config/dependencies.rb
@@ -1,5 +1,5 @@
 # Component dependencies
 disable_auto_import
 
-css_file '/assets/code_highlight/assets/css/default.css'
+css_file '/assets/code_highlight/assets/css/sunburst.css'
 javascript_file '/assets/code_highlight/assets/js/highlight.pack.js'

--- a/app/code_highlight/views/main/index.html
+++ b/app/code_highlight/views/main/index.html
@@ -1,1 +1,1 @@
-<code class="{{ attrs.language }}"></code>
+<pre class="{{ attrs.language }}"></pre>


### PR DESCRIPTION
`<code>` loses spacing from pre-evaluated text (like from a binding).
Here is an answer on StackOverflow going into more detail about this: http://stackoverflow.com/a/16065718/2636454
